### PR TITLE
removing json armor from docker output

### DIFF
--- a/lib/rake_docker/tasks/build.rb
+++ b/lib/rake_docker/tasks/build.rb
@@ -1,4 +1,5 @@
 require 'docker'
+require 'json'
 require_relative '../tasklib'
 
 module RakeDocker
@@ -43,7 +44,7 @@ module RakeDocker
           Docker::Image.build_from_dir(
               File.join(work_directory, image_name),
               {t: repository_name}) do |chunk|
-            $stdout.puts chunk
+            $stdout.puts JSON.parse(chunk)['stream']
           end
         end
       end

--- a/lib/rake_docker/version.rb
+++ b/lib/rake_docker/version.rb
@@ -1,3 +1,3 @@
 module RakeDocker
-  VERSION = '0.12.0'
+  VERSION = '0.12.1'
 end

--- a/spec/rake_docker/tasks/build_spec.rb
+++ b/spec/rake_docker/tasks/build_spec.rb
@@ -188,8 +188,8 @@ describe RakeDocker::Tasks::Build do
 
     allow(Docker::Image)
         .to(receive(:build_from_dir)
-                .and_yield('progress-message-1')
-                .and_yield('progress-message-2'))
+                .and_yield('{"stream":"progress-message-1"}')
+                .and_yield('{"stream":"progress-message-2"}'))
     expect($stdout)
         .to(receive(:puts)
                 .with('progress-message-1'))


### PR DESCRIPTION
all output from docker gets wrapped in {stream:"blah\n"} that makes it quite hard to read.
this is a quick and dirty attempt at fixing it, please let me know what you think.