### PR TITLE
Make `ensure_image_available` compatible with the Docker api >= v1.25

### DIFF
--- a/lib/rake_docker/container.rb
+++ b/lib/rake_docker/container.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'docker'
+require 'json'
 
 module RakeDocker
   module Container
@@ -179,7 +180,7 @@ module RakeDocker
 
       def ensure_image_available(image)
         reporter.checking_if_image_available(image)
-        matching_images = Docker::Image.all(filter: image)
+        matching_images = Docker::Image.all(filters: filters(image))
         if matching_images.empty?
           reporter.image_not_available(image)
           pull_image(image)
@@ -303,4 +304,12 @@ module RakeDocker
       end
     end
   end
+end
+
+def filters(image)
+  JSON.generate(
+    {
+      reference: [image]
+    }
+  )
 end

--- a/spec/rake_docker/container_spec.rb
+++ b/spec/rake_docker/container_spec.rb
@@ -2,6 +2,7 @@
 
 require 'spec_helper'
 require 'docker'
+require 'json'
 
 describe RakeDocker::Container do
   context RakeDocker::Container::Provisioner do
@@ -90,7 +91,7 @@ describe RakeDocker::Container do
         .to(receive(:get).with(name)
                          .and_raise(Docker::Error::NotFoundError))
       allow(Docker::Image)
-        .to(receive(:all).with(filter: image)
+        .to(receive(:all).with(filters: filters(image))
                          .and_return([underlying_image]))
       allow(Docker::Image).to(receive(:create))
       allow(Docker::Container)
@@ -135,7 +136,7 @@ describe RakeDocker::Container do
         .to(receive(:get).with(name)
                          .and_raise(Docker::Error::NotFoundError))
       allow(Docker::Image)
-        .to(receive(:all).with(filter: image)
+        .to(receive(:all).with(filters: filters(image))
                          .and_return([]))
       allow(Docker::Image)
         .to(receive(:create).with(fromImage: image))
@@ -188,7 +189,7 @@ describe RakeDocker::Container do
         .to(receive(:get).with(name)
                          .and_raise(Docker::Error::NotFoundError))
       allow(Docker::Image)
-        .to(receive(:all).with(filter: image)
+        .to(receive(:all).with(filters: filters(image))
                          .and_return([underlying_image]))
       allow(underlying_container).to(receive(:start))
       allow(Docker::Container)
@@ -221,7 +222,7 @@ describe RakeDocker::Container do
         .to(receive(:get).with(name)
                          .and_raise(Docker::Error::NotFoundError))
       allow(Docker::Image)
-        .to(receive(:all).with(filter: image)
+        .to(receive(:all).with(filters: filters(image))
                          .and_return([underlying_image]))
       allow(underlying_container).to(receive(:start))
 
@@ -272,7 +273,7 @@ describe RakeDocker::Container do
               .and_raise(Docker::Error::NotFoundError))
       allow(Docker::Image)
         .to(receive(:all)
-              .with(filter: image)
+              .with(filters: filters(image))
               .and_return([underlying_image]))
       allow(Docker::Container)
         .to(receive(:create)
@@ -402,4 +403,12 @@ class MockDockerContainer
   def json
     { 'State' => { 'Status' => status } }
   end
+end
+
+def filters(image)
+  JSON.generate(
+    {
+      reference: [image]
+    }
+  )
 end


### PR DESCRIPTION
With Docker API v1.25 the query parameter `filter` has been removed from the list-images api. Compare [v1.24](https://docs.docker.com/engine/api/v1.24/#list-images) with [v1.25](https://docs.docker.com/engine/api/v1.25/#tag/Image/operation/ImageList). 

This PR is to fix the `ensure_image_available` to make it work with >=v1.25.

## How to reproduce the issue

Run this code from your Rakefile:
```
RakeDocker.define_container_tasks(
      container_name: 'test') do |t|
      t.image = 'redis:7.0.10'
      t.environment = []
```
Where t.image is the name of an image you don't have locally. You expect the image to be pulled but the task will fail with 404 error.

## How Has This Been Tested?
- Unit test
- Manual test on docker v1.41

Useful command: `curl --unix-socket /var/run/docker.sock http://localhost/images/json\?filters\="\{\"reference\":\[\"postgres:11.16\"\]\}"`

Authors: @grierson @francesco-losciale